### PR TITLE
[BUGFIX] Migrate deprecated set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,4 +113,4 @@ runs:
       working-directory: t3docsproject
       run: |
         rm -Rf RenderedDocumentation
-        echo "::set-output name=renderedPath::t3docsproject/FinalDocumentation/"
+        echo "renderedPath=t3docsproject/FinalDocumentation/" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub deprecated `set-output` in favor of environment files
due to security reasons. See [1] for further information.

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/