### PR TITLE
[TASK] Add arguments to github action call

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,8 @@ runs:
         working-directory: t3docsproject
         config: ./Documentation/
         output: ./RenderedDocumentation/Result/project/0.0.0
+      args: |
+        -vvv --config ./Documentation/
 
     - id: jobfile
       if: steps.enable_guides.outputs.GUIDES == 'false'


### PR DESCRIPTION
Currently the configuration does not seem to be passed along properly.

The `args` attribute in the YAML configuration should allow us to pass this on.