### PR TITLE
[TASK] Use render-guides:stable for the render-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: mkdir -p RenderedDocumentation/Result/project/0.0.0
 
-    - uses: TYPO3-Documentation/render-guides@main
+    - uses: TYPO3-Documentation/render-guides@stable
       id: render-guides
       if: steps.enable_guides.outputs.GUIDES == 'true'
       with:


### PR DESCRIPTION
Only this way we can provide a "stable" TYPO3 Azure URI.

For "main" the Azure URI would be resolved statically.