### PR TITLE
[TASK] Revert back to using @main reference for GitHub action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: mkdir -p RenderedDocumentation/Result/project/0.0.0
 
-    - uses: TYPO3-Documentation/render-guides@stable
+    - uses: TYPO3-Documentation/render-guides@main
       id: render-guides
       if: steps.enable_guides.outputs.GUIDES == 'true'
       with:


### PR DESCRIPTION
We'll not use this 'stable' notation, so we need to revert this change.