### PR TITLE
[BUGFIX] Use absolute directory for render-guides working-dir

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
       id: render-guides
       if: steps.enable_guides.outputs.GUIDES == 'true'
       with:
-        working-directory: t3docsproject
+        working-directory: /github/workspace/t3docsproject
         config: ./t3docsproject/Documentation/
         output: ./RenderedDocumentation/Result/project/0.0.0
         configure-branch: ${{ env.source_branch }}


### PR DESCRIPTION
The github action passes a "working-dir" parameter to render-guides (do NOT confuse this with "working-directory" as a base parameter in github actions themselves).

For localization renderings, the relativ directory to the workspace is different, because PHP is executed in a sub-shell where the working directory is already a different one.

The easiest way to fix this is to use the absolute directory reference when spawning the render-guides binary, so it can be properly executed.

In a future PR we can try to tidy this up to make localization rendering also recognize the parent working directory and utilize that one, instead of the actuall shell directory of the call.

Nobody reads this anyways, so let's merge. ;-)