### PR TITLE
[BUGFIX] Use absolute config directory for render-guides

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       if: steps.enable_guides.outputs.GUIDES == 'true'
       with:
         working-directory: /github/workspace/t3docsproject
-        config: ./t3docsproject/Documentation/
+        config: /github/workspace/t3docsproject/Documentation/
         output: ./RenderedDocumentation/Result/project/0.0.0
         configure-branch: ${{ env.source_branch }}
         configure-project-release: ${{ env.target_branch_directory }}


### PR DESCRIPTION
As a follow-up to https://github.com/TYPO3-Documentation/gh-render-action/commit/b0a7f230943331e9d19e1e4340dbae34c962e423 this also fixates the "config" directory of the render-guides call.

Otherwise, the localization sub-render process will try to reference the "guides.xml" with a different working directory than the initial call for the "english" rendering.

This should hopefully properly inject all language-specific attributes to the rendering, showing a language menu for localizations.